### PR TITLE
Add basic support for slash extensions :tada:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@ docs/crowdin.py
 *.jpg
 *.flac
 *.mo
-*.test.py
+*.test.*
 build/
 dist/

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -576,7 +576,7 @@ class ApplicationCommand:
             self._permissions: List[ApplicationCommandGuildPermissions] = [] # type: ignore
 
         for perm in self._permissions:
-            perm.command = self
+            perm._command = self
 
         if self._type in (
             ApplicationCommandType.user,
@@ -1631,7 +1631,7 @@ def application_command_permission(*, guild_id: int, user_id: int = None, role_i
         for perm in func.__application_command_permissions__:
             if perm.guild_id == guild_id:
                 found = True
-                perm.permissions.append(
+                perm._permissions.append(
                     ApplicationCommandPermission(
                         id=id,
                         type=type,

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -1141,11 +1141,15 @@ class SlashCommandChild(Option):
 
 
     def to_dict(self) -> dict:
+        options = self.options
+        if isinstance(self, SlashSubCommand) and isinstance(self._parent, SlashCommandGroup):
+            options.reverse()
+        
         return {
             'name': self._name,
             'description': self._description,
             'type': self._type.value,
-            'options': [option.to_dict() for option in self.options],
+            'options': [option.to_dict() for option in options],
         }
 
 
@@ -1316,7 +1320,7 @@ class SlashSubCommand(SlashCommandChild):
             OptionType.sub_command.value,
             **attrs
         )
-        self._parent = None
+        self._parent: Union[SlashCommand, SlashCommandGroup] = None # type: ignore
 
 
     # Option management

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -238,9 +238,9 @@ class Option:
 
         .. info::
             Though this is determined by the annotation of parameter that represents
-            this option in the callback function, Due to how Discord's Enum work, 
-            For precise selection of channel types, Pass the list of desired channel
-            types in ``channel_types`` parameter in :class:`Option`
+            this option in the callback function, It should be noted that due to how 
+            Discord's Enum work, For precise selection of channel types, Pass the list of 
+            desired :class:`ChannelType` in ``channel_types`` parameter in :class:`Option`
         """
         return self._channel_types
 

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -478,8 +478,6 @@ class Option:
         return dict_
 
 
-# TODO: Work on Application command permissions.
-
 
 class ApplicationCommandGuildPermissions:
     """Represents the permissions for an application command in a :class:`Guild`.
@@ -1157,16 +1155,12 @@ class SlashCommandChild(Option):
         return await utils.async_all(predicate(ctx) for predicate in predicates)  # type: ignore
 
 
-    def to_dict(self) -> dict:
-        options = self.options
-        if isinstance(self, SlashSubCommand) and isinstance(self._parent, SlashCommandGroup):
-            options.reverse()
-        
+    def to_dict(self) -> dict:            
         return {
             'name': self._name,
             'description': self._description,
             'type': self._type.value,
-            'options': [option.to_dict() for option in options],
+            'options': [option.to_dict() for option in self._options],
         }
 
 
@@ -1252,7 +1246,7 @@ class SlashCommandGroup(SlashCommandChild):
         child._parent = self
         self._options.append(child)
         self._children.append(child)
-
+        
         for opt in child.callback.__annotations__.values():
             if isinstance(opt, Option):
                 child.append_option(opt)
@@ -1309,6 +1303,8 @@ class SlashCommandGroup(SlashCommandChild):
             return self.add_child(SlashSubCommand(func, **attrs))
 
         return inner
+
+
 
 class SlashSubCommand(SlashCommandChild):
     """Represents a subcommand of a slash command.

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -728,7 +728,7 @@ class ApplicationCommand:
 
         This is the non-decorator interface to :func:`.check`.
 
-        .. versionadded:: 1.3
+        .. versionadded:: 2.0
 
         Parameters
         -----------
@@ -744,7 +744,7 @@ class ApplicationCommand:
         This function is idempotent and will not raise an exception
         if the function is not in the command's checks.
 
-        .. versionadded:: 1.3
+        .. versionadded:: 2.0
 
         Parameters
         -----------
@@ -764,7 +764,7 @@ class ApplicationCommand:
         inside the :attr:`~ApplicationCommand.checks` attribute. This also checks whether the
         command is disabled.
 
-        .. versionchanged:: 1.3
+        .. versionchanged:: 2.0
             Checks whether the command is disabled or not
 
         Parameters
@@ -1021,7 +1021,7 @@ class SlashCommandChild(Option):
 
         This is the non-decorator interface to :func:`.check`.
 
-        .. versionadded:: 1.3
+        .. versionadded:: 2.0
 
         Parameters
         -----------
@@ -1037,7 +1037,7 @@ class SlashCommandChild(Option):
         This function is idempotent and will not raise an exception
         if the function is not in the command's checks.
 
-        .. versionadded:: 1.3
+        .. versionadded:: 2.0
 
         Parameters
         -----------
@@ -1057,7 +1057,7 @@ class SlashCommandChild(Option):
         inside the :attr:`~ApplicationCommand.checks` attribute. This also checks whether the
         command is disabled.
 
-        .. versionchanged:: 1.3
+        .. versionchanged:: 2.0
             Checks whether the command is disabled or not
 
         Parameters

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -544,6 +544,9 @@ class ApplicationCommand:
     checks: List[Callable[:class:`InteractionContext`, bool]]
         The list of checks this commands holds that will be checked before command's
         invocation.
+
+        For more info on checks and how to register them, See :func:`~ext.commands.check` 
+        documentation as these checks actually come from there.
     """
     def __init__(self, callback: Callable, **attrs: Any):
         self._callback = callback

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -108,7 +108,7 @@ def get_signature_parameters(function: Callable[..., Any], globalns: Dict[str, A
     return params
 
 Check = Callable[[InteractionContext, 'Context'], bool]
-    
+
 class OptionChoice:
     """Represents an option choice for an application command's option.
 
@@ -190,7 +190,7 @@ class Option:
         choices: List[OptionChoice] = None,
         required: bool = True,
         arg: str = None,
-        converter: Any = None # todo: proper typehint
+        converter: 'Converter' = None # todo: proper typehint
     ):
         try:
             self._type: OptionType = OptionType.from_datatype(type)
@@ -207,7 +207,7 @@ class Option:
             self._choices = []
 
         self._options: List[Option] = []
-        self.converter = converter # type: ignore
+        self.converter: 'Converter' = converter # type: ignore
 
         self._parent: Union[ApplicationCommand, Option] = None # type: ignore
 

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -906,6 +906,7 @@ class ApplicationCommand:
                 # just options of a command. And option names are unique
 
                 subcommand = self.get_child(name=option['name'])
+                context.command = subcommand
                 sub_options = option.get('options', [])
 
                 for sub_option in sub_options:
@@ -928,6 +929,7 @@ class ApplicationCommand:
                 group = self.get_child(name=option['name'])
                 sub_options = subcommand_raw.get('options', [])
                 subcommand = group.get_child(name=subcommand_raw['name'])
+                context.command = subcommand
 
                 for sub_option in sub_options:
                     value = await self._parse_option(interaction, sub_option)
@@ -941,19 +943,15 @@ class ApplicationCommand:
                 break
 
             else:
+                if context.command is None:
+                    context.command = self
+
                 value = await self._parse_option(interaction, option)
                 option = self.get_option(name=option['name'])
                 if option.converter is not None:
                     kwargs[option.arg] = option.converter().convert(value)
                 kwargs[option.arg] = value
 
-        if command is None:
-            # if we're here, that means that a simple slash command
-            # was invoked with no options/subcommands that's why it wasn't set during
-            # options parsing.
-            command = self
-
-        context.command = command
         if not (await command.can_run(context)):
             raise ApplicationCommandCheckFailure(f'checks functions for application command {command._name} failed.')
 

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -182,6 +182,9 @@ class Option:
     converter: Optional[:class:`~ext.commands.Converter`]
         The converter of this option. This is derived directly from converters in 
         commands extension. Read about :class:`ext.commands.Converter`
+    channel_types: List[:class:`ChannelType`]
+        The channel types to show, If :attr:`Option.type` is :attr:`OptionType.channel`.
+        This is determined by the annotation of the option in callback function.
     """
     def __init__(self, *,
         name: str,
@@ -227,6 +230,20 @@ class Option:
     def name(self) -> str:
         """:class:`str`: The name of option."""
         return self._name
+
+    @property
+    def channel_types(self) -> List[ChannelType]:
+        """List[:class:`ChannelType`]: The channel types to show, If :attr:`Option.type` 
+        is :attr:`OptionType.channel`.
+
+        .. info::
+            Though this is determined by the annotation of parameter that represents
+            this option in the callback function, Due to how Discord's Enum work, 
+            For precise selection of channel types, Pass the list of desired channel
+            types in ``channel_types`` parameter in :class:`Option`
+        """
+        return self._channel_types
+
 
     @property
     def description(self) -> str:

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -2217,7 +2217,6 @@ class Client:
             The interaction to handle. If the interaction is not a application command interaction,
             then this will silently ignore the interaction.
         """
-        print(interaction.data)
         if not interaction.is_application_command():
             return
 

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -2038,6 +2038,7 @@ class Client:
                         # make the command in the guild
                         if ignore_guild_register_fail:
                             traceback.print_exc()
+                            continue
                         else:
                             raise e
             else:
@@ -2112,6 +2113,7 @@ class Client:
                 # bot doesn't has application.commands scope
                 if ignore_guild_register_fail:
                     traceback.print_exc()
+                    continue
                 else:
                     raise e
             for cmd in cmds:
@@ -2215,6 +2217,7 @@ class Client:
             The interaction to handle. If the interaction is not a application command interaction,
             then this will silently ignore the interaction.
         """
+        print(interaction.data)
         if not interaction.is_application_command():
             return
 

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -2031,7 +2031,7 @@ class Client:
             command = self._pending_commands[index]
             if command.guild_ids:
                 for guild_id in command.guild_ids:
-                    try:
+                    try:            
                         cmd = await self.http.upsert_guild_command(self.user.id, guild_id, command.to_dict())
                     except Forbidden as e:
                         # the bot is missing application.commands scope so cannot
@@ -2042,7 +2042,8 @@ class Client:
                         else:
                             raise e
             else:
-                cmd = await self.http.upsert_global_command(self.user.id, command.to_dict())
+                data = command.to_dict()            
+                cmd = await self.http.upsert_global_command(self.user.id, data)
 
             self._connection._application_commands[int(cmd['id'])] = command._from_data(cmd)
             self._pending_commands.pop(index)

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -1859,7 +1859,7 @@ class Client:
 
         return resolved
 
-    async def sync_application_command_permissions(self):
+    async def sync_application_commands_permissions(self):
         """|coro|
 
         Synchronizes the application command permissions to API.
@@ -2047,7 +2047,7 @@ class Client:
 
 
         # finally, batch-editing the permissions
-        await self.sync_application_command_permissions()
+        await self.sync_application_commands_permissions()
 
         _log.info('Application commands have been synchronised with the internal cache successfully.')
 
@@ -2117,7 +2117,7 @@ class Client:
                 self._connection._application_commands[int(cmd['id'])] = utils.get(self._pending_commands, name=cmd['name'])._from_data(cmd)
 
         # finally, batch-editing the permissions
-        await self.sync_application_command_permissions()
+        await self.sync_application_commands_permissions()
 
 
         _log.info('Registered %s commands successfully.' % str(len(self._pending_commands)))

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -43,6 +43,7 @@ from .channel import _threaded_channel_factory, PartialMessageable
 from .enums import ChannelType
 from .mentions import AllowedMentions
 from .errors import *
+from .errors import _BaseCommandError
 from .enums import Status, VoiceRegion, ApplicationCommandType, OptionType
 from .flags import ApplicationFlags, Intents
 from .gateway import *
@@ -2229,7 +2230,14 @@ class Client:
 
         try:
             await command.invoke(context)
-        except ApplicationCommandError as error:
+        except (ApplicationCommandError, _BaseCommandError) as error:
+            # here comes the important part, There have been many concerns about error handlers
+            # of legacy commands and application commands.
+            # we need seperate handlers for each type, the reason behind this is purely
+            # based on the fact that prefixed commands are NOT same as application commands
+            # and have different implementation. there can be more complicated issues
+            # if we merge the handlers or in general, these two unlike systems so there
+            # is no possibility of them to be merged in one!
             self.dispatch('application_command_error', context, error)
         else:
             self.dispatch('application_command_completion', context)

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -2187,7 +2187,7 @@ class Client:
     async def process_application_commands(self, interaction: Interaction) -> Any:
         """|coro|
 
-        Handles an application command interaction.  This function holds the application
+        Handles an application command interaction. This function holds the application
         command main processing logic.
 
         This function is used under-the-hood to handle all the application commands interactions.

--- a/diskord/enums.py
+++ b/diskord/enums.py
@@ -688,13 +688,15 @@ class OptionType(Enum, comparable=True):
                     except KeyError:
                         # unknown type in typing.Union? ignore it.
                         pass
+                    else:
+                        return cls.channel
             else:
                 try:
                     option._channel_types.append(channel_types_map[annotation.__name__])
                 except KeyError:
                     pass
-
-            return cls.channel
+                else:
+                    return cls.channel
         
         return cls.string
 

--- a/diskord/errors.py
+++ b/diskord/errors.py
@@ -53,6 +53,8 @@ __all__ = (
     'PrivilegedIntentsRequired',
     'InteractionResponded',
     'ApplicationCommandError',
+    'ApplicationCommandCheckFailure',
+    'ApplicationCommandConversionError',
 )
 
 
@@ -306,3 +308,24 @@ class ApplicationCommandCheckFailure(ApplicationCommandError):
     commands and is not sent in :func:`on_command_error` but in :func:`on_application_command_error`
     """
     pass
+
+class ApplicationCommandConversionError(ApplicationCommandError):
+    """Exception raised when a :class:`~ext.commands.Converter` class raises 
+    non-ApplicationCommandError.
+
+    This inherits from :exc:`ApplicationCommandError`.
+
+    This class is similar to :exc:`~ext.commands.ConversionError` but it is for application
+    commands and is not sent in :func:`on_command_error` but in :func:`on_application_command_error`
+
+    Attributes
+    ----------
+    converter: :class:`diskord.ext.commands.Converter`
+        The converter that failed.
+    original: :exc:`Exception`
+        The original exception that was raised. You can also get this via
+        the ``__cause__`` attribute.
+    """
+    def __init__(self, converter: 'Converter', original: Exception) -> None:
+        self.converter: Converter = converter
+        self.original: Exception = original

--- a/diskord/errors.py
+++ b/diskord/errors.py
@@ -56,6 +56,7 @@ __all__ = (
 )
 
 
+
 class DiscordException(Exception):
     """Base exception class for diskord
 
@@ -277,12 +278,30 @@ class InteractionResponded(ClientException):
         self.interaction: Interaction = interaction
         super().__init__('This interaction has already been responded to before')
 
+
+class _BaseCommandError(Exception):
+    # this class is (kind of a) base class for application command errors discord.ext.commands.CommandError 
+    # and purely exists for instance checking purposes to avoid circular import issues.
+    # bad yet only implementation
+    pass
+
 class ApplicationCommandError(ClientException):
     """Base exception from which other application commands exceptions are derived.
-    
-    This class is really useful to create custom exceptions which you can handle in
+
+    This class is similar to :class:`~commands.CommandError` but it is for application
+    commands.
+
+    This class is useful to create custom exceptions which you can handle in
     :func:`on_application_command_error`. An exception that subclasses this class
     that is raised in an application command will be passed to :func:`on_application_command_error`
-    listener. 
+    listener.
+    """
+    pass
+
+class ApplicationCommandCheckFailure(ApplicationCommandError):
+    """A unique exception indicating that checks for an application command failed.
+
+    This class is similar to :class:`~commands.CheckFailure` but it is for application
+    commands and is not sent in :func:`on_command_error` but in :func:`on_application_command_error`
     """
     pass

--- a/diskord/errors.py
+++ b/diskord/errors.py
@@ -280,9 +280,10 @@ class InteractionResponded(ClientException):
 
 
 class _BaseCommandError(Exception):
-    # this class is (kind of a) base class for application command errors discord.ext.commands.CommandError 
-    # and purely exists for instance checking purposes to avoid circular import issues.
-    # bad yet only implementation
+    # this class is kind of a hacky base class for errors in discord.ext.commands stuff 
+    # that is used in application commands like checks, this is purely for instance checking
+    # and avoiding circular import issues. Yeah, not the best implementation but the only
+    # implementation I could possibly think of.
     pass
 
 class ApplicationCommandError(ClientException):

--- a/diskord/errors.py
+++ b/diskord/errors.py
@@ -280,10 +280,10 @@ class InteractionResponded(ClientException):
 
 
 class _BaseCommandError(Exception):
-    # this class is kind of a hacky base class for errors in discord.ext.commands stuff 
-    # that is used in application commands like checks, this is purely for instance checking
-    # and avoiding circular import issues. Yeah, not the best implementation but the only
-    # implementation I could possibly think of.
+    # this class is kind of a hacky base class for errors from discord.ext.commands for stuff
+    # that comes from there that is used in application commands like checks, this is purely for 
+    # instance checking and avoiding circular import issues. 
+    # Yeah, not the best implementation but the only implementation I could possibly think of.
     pass
 
 class ApplicationCommandError(ClientException):

--- a/diskord/ext/commands/cog.py
+++ b/diskord/ext/commands/cog.py
@@ -28,7 +28,7 @@ import diskord.utils
 
 from typing import Any, Callable, ClassVar, Dict, Generator, List, Optional, TYPE_CHECKING, Tuple, TypeVar, Type
 
-from diskord import ApplicationCommand
+from diskord import ApplicationCommand, Option
 from ._types import _BaseCommand
 
 if TYPE_CHECKING:
@@ -464,6 +464,12 @@ class Cog(metaclass=CogMeta):
 
         for index, command in enumerate(self.__cog_application_commands__):
             command._cog = self
+            if command.id is not None:
+                # if we're here then command is registered and synced and we
+                # just have to add it to application commands list and it 
+                # would start working as normal.
+                bot._connection._application_commands[int(command.id)] = command
+                continue
 
             try:
                 bot.add_pending_command(command)

--- a/diskord/ext/commands/core.py
+++ b/diskord/ext/commands/core.py
@@ -1641,12 +1641,20 @@ def check(predicate: Check) -> Callable[[T], T]:
     These checks should be predicates that take in a single parameter taking
     a :class:`.Context`. If the check returns a ``False``\-like value then
     during invocation a :exc:`.CheckFailure` exception is raised and sent to
-    the :func:`.on_command_error` event.
+    the :func:`.on_command_error` event or :func:`~diskord.on_application_command_error` in
+    case of application commands.
 
     If an exception should be thrown in the predicate then it should be a
-    subclass of :exc:`.CommandError`. Any exception not subclassed from it
+    subclass of :exc:`.CommandError` or :class:`ApplicationCommandError` in case of application
+    commands. Any exception not subclassed from it
     will be propagated while those subclassed will be sent to
-    :func:`.on_command_error`.
+    :func:`.on_command_error` or :func:`~diskord.on_application_command_error` in
+    case of application commands.
+
+    .. warning::
+        If a check added on an application command fails then :func:`~diskord.on_application_command_error`
+        is invoked instead of :func:`.on_command_error`, Similarly, :func:`.on_command_error`
+        is not compatible with application commands. 
 
     A special attribute named ``predicate`` is bound to the value
     returned by this decorator to retrieve the predicate passed to the

--- a/diskord/ext/commands/errors.py
+++ b/diskord/ext/commands/errors.py
@@ -117,7 +117,7 @@ class CommandError(DiscordException):
         else:
             super().__init__(*args)
 
-class ConversionError(CommandError):
+class ConversionError(CommandError, _BaseCommandError):
     """Exception raised when a Converter class raises non-CommandError.
 
     This inherits from :exc:`CommandError`.

--- a/diskord/ext/commands/errors.py
+++ b/diskord/ext/commands/errors.py
@@ -117,7 +117,7 @@ class CommandError(DiscordException):
         else:
             super().__init__(*args)
 
-class ConversionError(CommandError, _BaseCommandError):
+class ConversionError(CommandError):
     """Exception raised when a Converter class raises non-CommandError.
 
     This inherits from :exc:`CommandError`.

--- a/diskord/ext/commands/errors.py
+++ b/diskord/ext/commands/errors.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 from typing import Optional, Any, TYPE_CHECKING, List, Callable, Type, Tuple, Union
 
-from diskord.errors import ClientException, DiscordException
+from diskord.errors import ClientException, DiscordException, _BaseCommandError
 
 if TYPE_CHECKING:
     from inspect import Parameter
@@ -184,7 +184,7 @@ class BadArgument(UserInputError):
     """
     pass
 
-class CheckFailure(CommandError):
+class CheckFailure(CommandError, _BaseCommandError):
     """Exception raised when the predicates in :attr:`.Command.checks` have failed.
 
     This inherits from :exc:`CommandError`

--- a/diskord/guild.py
+++ b/diskord/guild.py
@@ -220,7 +220,7 @@ class Guild(Hashable):
         - ``VERIFIED``: Guild is a verified server.
         - ``VIP_REGIONS``: Guild has VIP voice regions.
         - ``WELCOME_SCREEN_ENABLED``: Guild has enabled the welcome screen.
-        - ``ROLE_SUBSCRIPTIONS_ENABLED``: Guild has role subscriptions enabled.
+        - ``ROLE_ICONS``: Guild can set role icons.
 
     premium_tier: :class:`int`
         The premium tier for this guild. Corresponds to "Nitro Server" in the official UI.

--- a/diskord/interactions.py
+++ b/diskord/interactions.py
@@ -814,6 +814,7 @@ class InteractionContext:
         # bot alias exists for being consistent commands.Bot models
         self.bot = client
         self.interaction = interaction
+        self._state = self.interaction._state
 
     @property
     def channel(self) -> abc.Snowflake:
@@ -838,6 +839,24 @@ class InteractionContext:
     author = user
 
     @property
+    def me(self) -> Union[Member, User]:
+        """
+        Union[:class:`Member`, :class:`User`]: Similar to :attr:`.Guild.me` except it may
+        return the :class:`.ClientUser` in private message contexts.
+        """
+        return self.guild.me if self.guild is not None else self.bot.user  # type: ignore
+
+    @property
+    def voice_client(self) -> Optional[VoiceProtocol]:
+        r"""Optional[:class:`.VoiceProtocol`]: A shortcut to :attr:`.Guild.voice_client`\, if applicable."""
+        g = self.guild
+        return g.voice_client if g else None
+
+    @utils.copy_doc(Message.reply)
+    async def reply(self, content: Optional[str] = None, **kwargs: Any) -> Message:
+        return await self.message.reply(content, **kwargs)
+
+    @property
     def response(self) -> InteractionResponse:
         """:class:`InteractionResponse`: The response of interaction."""
         return self.interaction.response
@@ -859,6 +878,3 @@ class InteractionContext:
     @property
     def followup(self) -> Callable:
         return self.interaction.followup
-
-# Application commands
-

--- a/diskord/interactions.py
+++ b/diskord/interactions.py
@@ -814,7 +814,10 @@ class InteractionContext:
         # bot alias exists for being consistent commands.Bot models
         self.bot = client
         self.interaction = interaction
-        self._state = self.interaction._state
+        self.command: ApplicationCommand = None # type: ignore
+        self._state: ConnectionState = self.interaction._state
+
+
 
     @property
     def channel(self) -> abc.Snowflake:

--- a/diskord/message.py
+++ b/diskord/message.py
@@ -158,7 +158,9 @@ class Attachment(Hashable):
 
     """
 
-    __slots__ = ('id', 'size', 'height', 'width', 'filename', 'url', 'proxy_url', '_http', 'content_type')
+    __slots__ = ('id', 'size', 'height', 'width', 'filename', 'url',
+                'proxy_url', '_http', 'content_type', 'ephemeral'
+                )
 
     def __init__(self, *, data: AttachmentPayload, state: ConnectionState):
         self.id: int = int(data['id'])

--- a/diskord/role.py
+++ b/diskord/role.py
@@ -249,10 +249,12 @@ class Role(Hashable):
         self.mentionable: bool = data.get('mentionable', False)
         self.tags: Optional[RoleTags]
         self._icon: Optional[Asset] = data.get('icon')
-        try:
-            self.unicode_emoji: Optional[PartialEmoji] = PartialEmoji.from_str(data['unicode_emoji'])
-        except KeyError:
-            self.unicode_emoji: Optional = None
+        
+        # TODO:
+        # try:
+        #     self.unicode_emoji: Optional[PartialEmoji] = PartialEmoji.from_str(str(data['unicode_emoji']))
+        # except KeyError:
+        #     self.unicode_emoji: Optional[PartialEmoji] = None
 
 
         try:

--- a/diskord/role.py
+++ b/diskord/role.py
@@ -32,6 +32,7 @@ from .colour import Colour
 from .mixins import Hashable
 from .utils import snowflake_time, _get_as_snowflake, MISSING
 from .asset import Asset
+from .partial_emoji import PartialEmoji
 
 __all__ = (
     'RoleTags',
@@ -187,6 +188,7 @@ class Role(Hashable):
         'guild',
         'tags',
         '_state',
+        'unicode_emoji',
     )
 
     def __init__(self, *, guild: Guild, state: ConnectionState, data: RolePayload):
@@ -247,6 +249,11 @@ class Role(Hashable):
         self.mentionable: bool = data.get('mentionable', False)
         self.tags: Optional[RoleTags]
         self._icon: Optional[Asset] = data.get('icon')
+        try:
+            self.unicode_emoji: Optional[PartialEmoji] = PartialEmoji.from_str(data['unicode_emoji'])
+        except KeyError:
+            self.unicode_emoji: Optional = None
+
 
         try:
             self.tags = RoleTags(data['tags'])
@@ -372,6 +379,7 @@ class Role(Hashable):
         hoist: bool = MISSING,
         mentionable: bool = MISSING,
         icon: Optional[bytes] = MISSING,
+        unicode_emoji: Optional[str] = MISSING,
         position: int = MISSING,
         reason: Optional[str] = MISSING,
     ) -> Optional[Role]:
@@ -404,8 +412,11 @@ class Role(Hashable):
             Indicates if the role should be mentionable by others.
         icon: Optional[:class:`bytes`]
             A :term:`py:bytes-like object` representing the icon of the role. Only PNG/JPEG is supported.
-            Could be ``None`` to denote removal of the icon. Role's guild must has ``ROLE_SUBSCRIPTIONS_ENABLED``
+            Could be ``None`` to denote removal of the icon. Role's guild must has ``ROLE_ICONS``
             in :attr:`Guild.features`
+        unicode_emoji: Union[:class:`str`, :class:`PartialEmoji`]:
+            The unicode emoji string for role icon. ``None`` denotes the removal of 
+            unicode emoji.
         position: :class:`int`
             The new role's position. This must be below your top role's
             position or it will fail.
@@ -457,6 +468,12 @@ class Role(Hashable):
                 payload['icon'] = icon
             else:
                 payload['icon'] = utils._bytes_to_base64_data(icon)
+
+        if unicode_emoji is not MISSING:
+            if unicode_emoji is None:
+                payload['unicode_emoji'] = str(unicode_emoji)
+            else:
+                payload['unicode_emoji'] = str(unicode_emoji)
 
         data = await self._state.http.edit_role(self.guild.id, self.id, reason=reason, **payload)
         return Role(guild=self.guild, data=data, state=self._state)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -655,25 +655,17 @@ to handle it, which defaults to print a traceback and ignoring the exception.
     This is a really helpful event and acts as an error handler for your application
     commands.
 
+    .. info::
+        This is not same as :func:`~commands.on_command_error` as it only is for application
+        commands. For example, if you register a :func:`~commands.check` on an application
+        command, Then if that check fails and raises an error, that error would be passed
+        in this listener and **not** :func:`~commands.on_command_error`.
+
+        This leads to usage of two seperate handlers for application commands and prefixed
+        commands and that is only solution as both systems are entirely different.
+
     You can create your own exceptions that subclass :class:`ApplicationCommandError` that
     you can raise in your commands and handle them within this event.
-
-    Usage: ::
-
-        class UserBlacklisted(diskord.ApplicationCommandError):
-            pass
-
-        @bot.command()
-        async def test(ctx):
-            if ctx.author.id == 123456789:
-                raise UserBlacklisted()
-
-        @bot.event
-        async def on_application_command_error(ctx, error):
-            if isinstance(error, ApplicationCommandError):
-                await ctx.send('You are blacklisted from using this command.')
-            else:
-                raise error
 
     .. versionadded:: 2.5
 

--- a/docs/ext/commands/api.rst
+++ b/docs/ext/commands/api.rst
@@ -73,6 +73,15 @@ are custom to the command extension module.
     inside a command either through user input error, check
     failure, or an error in your own code.
 
+    .. info::
+        This is not for application commands. For example, if you register a :func:`~commands.check`on an application command, Then if that check fails and raises an error, that error would 
+        **not** be passed to this but it would be passed in 
+        :func:`diskord.on_application_command_error` so it must be used in case of application
+        commands.
+
+        This leads to usage of two seperate handlers for application commands and prefixed
+        commands and that is only solution as both systems are entirely different.
+
     A default one is provided (:meth:`.Bot.on_command_error`).
 
     :param ctx: The invocation context.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -72,7 +72,7 @@ Consider the following example: ::
             if r.status == 200:
                 js = await r.json()
                 await channel.send(js['file'])
-                
+
 General
 ---------
 
@@ -84,7 +84,7 @@ Old application commands are not getting removed after I remove them from code!
 This is normal, You can simply override :func:`on_connect` event and set ``delete_unregistered_commands`` to ``True``:
 
 Usage: ::
-    
+
     @client.event
     async def on_connect():
         await client.sync_application_commands(delete_unregistered_commands=True)
@@ -94,12 +94,12 @@ Why do I get error: "Invalid Interaction Application Command"
 
 This is a Discord-related error. This usually happens with your **global** commands when you restart your bot. **Guild commands are not affected.**
 
-This error goes away after few minutes or even seconds. 
+This error goes away after few minutes or even seconds.
 
 .. tip::
     It is recommended to test your commands with :attr:`ApplicationCommand.guild_ids` with your testing server ID for easy testing.
     You will not encounter this error while testing if you specify :attr:`ApplicationCommand.guild_ids`
-    
+
 
 Where can I find usage examples?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -433,3 +433,20 @@ Example: ::
         await ctx.send(f'Pushing to {remote} {branch}')
 
 This could then be used as ``?git push origin master``.
+
+Why are application commands so different from commands?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is pretty clear that application commands are really different from commands.
+For example, If you're making an error handler that sends a message when a certain person
+is missing a permission then you have to make seperate error handlers for each type.
+
+i.e :func:`on_command_error` for prefixed-commands and :func:`on_application_command_error` for
+application commands.
+
+The sole reason is that, **Both have entirely different design.**, The prefixed commands are
+designed by library as an extension to aid in prefixed-commands creation whereas the
+application commands are part of Discord API.
+
+There's no way of merging application commands with prefixed-commands and it would lead to many
+unexpected issues.


### PR DESCRIPTION
This pull requests add the basic support slash command extensions and also fixes the options annotations bug!

## Summarized Checklist
- [x] Converters for slash commands
- [x] Checks for slash commands
- [x] Fix options annotations bug
- [x] Fix bug where member or user options were None in slash commands if member intents are missing.
- [x] Slash commands are resynced automatically between cog additions and removals without needing to recall `sync_application_commands`
- [x] Fix UnboundLocal error when application command registration fails in a guild.
- [x] **PARTIALLY** Implements role icons
- [x] Implements channel types for slash command options
- [x] Minor bug fixes       