### PR TITLE
Implement slash command options autocompletion 

### DIFF
--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -714,7 +714,7 @@ class Option:
 
     def can_autocomplete(self) -> bool:
         """:class:`bool`: Indicates whether this option can autocomplete or not."""
-        return (self.autocomplete is not None)
+        return bool(self.autocomplete)
 
     def to_dict(self) -> dict:
         dict_ = {

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -417,6 +417,33 @@ class Option:
     channel_types: List[:class:`ChannelType`]
         The channel types to show, If :attr:`Option.type` is :attr:`OptionType.channel`.
         This is determined by the annotation of the option in callback function.
+    autocomplete:
+        The function that would autocomplete this option if applicable.
+        If option does not has autocompletion, then this is ``None``.
+        
+        First parameter of function would represent the value of option that
+        is focused and second parameter is the autocompletion :class:`~diskord.Interaction`.
+
+        This function must be a coroutine.
+
+        Example: ::
+            
+            async def autocomplete(value, interaction):
+                data = {
+                    'Bun': 'bun',
+                    'Cookie': 'cookie',
+                    'Cake': 'cake',
+                }
+                return [
+                    diskord.OptionChoice(name=name, value=data[name])
+                    for name in data if name.startswith(value)
+                    ]
+
+            @bot.slash_command()
+            @diskord.slash_option('item', autocomplete=autocomplete)
+            async def buy(ctx, item):
+                await ctx.send(f'You bought {item}')
+
     """
 
     def __init__(
@@ -429,6 +456,7 @@ class Option:
         required: bool = True,
         arg: str = None,
         converter: "Converter" = None,
+        autocomplete: Callable[[str], List[OptionChoice]] = None,
         **attrs,
     ):
         self.callback: Callable[..., Any] = attrs.get("callback")
@@ -437,11 +465,13 @@ class Option:
         self._required = required
         self._channel_types: List[ChannelType] = attrs.get("channel_types", [])  # type: ignore
         self._choices: List[OptionChoice] = choices
+        self._options: List[Option] = []
+        self.autocomplete: Callable[[str], List[OptionChoice]] = autocomplete
+        
         if self._choices is None:
             self._choices = []
 
         self.arg = arg or self.name
-        self._options: List[Option] = []
         self.converter: "Converter" = converter  # type: ignore
 
         self._parent: Union[ApplicationCommand, Option] = None  # type: ignore
@@ -511,6 +541,7 @@ class Option:
     def options(self) -> List[Option]:
         """List[:class:`Option`]: The list of sub-options of this option."""
         return self._options
+
 
     # Choices management
 
@@ -674,12 +705,16 @@ class Option:
 
         return option
 
-    def is_command_or_group(self):
+    def is_command_or_group(self) -> bool:
         """:class:`bool`: Indicates whether this option is a subcommand or subgroup."""
         return self._type.value in (
             OptionType.sub_command.value,
             OptionType.sub_command_group.value,
         )
+
+    def can_autocomplete(self) -> bool:
+        """:class:`bool`: Indicates whether this option can autocomplete or not."""
+        return (self.autocomplete is not None)
 
     def to_dict(self) -> dict:
         dict_ = {
@@ -688,6 +723,7 @@ class Option:
             "description": self._description,
             "choices": [choice.to_dict() for choice in self._choices],
             "options": [option.to_dict() for option in reversed(self.options)],
+            "autocomplete": self.can_autocomplete(),
         }
 
         if not self.is_command_or_group():

--- a/diskord/application_commands.py
+++ b/diskord/application_commands.py
@@ -1230,6 +1230,7 @@ class UserCommand(ContextMenuCommand):
         if context.command.cog is not None:
             args.insert(0, context.command.cog)
 
+        self._bot.dispatch('application_command_run', context)
         await context.command.callback(*args)
 
 
@@ -1287,6 +1288,7 @@ class MessageCommand(ContextMenuCommand):
         if context.command.cog is not None:
             args.insert(0, context.command.cog)
 
+        self._bot.dispatch('application_command_run', context)
         await context.command.callback(*args)
 
 
@@ -1498,6 +1500,7 @@ class SlashCommand(ApplicationCommand, ChildrenMixin, OptionsMixin):
         if context.command.cog is not None:
             args.insert(0, context.command.cog)
 
+        self._bot.dispatch('application_command_run', context)
         await context.command.callback(*args, **kwargs)
 
     # decorators

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -2453,7 +2453,6 @@ class Client:
             return
 
         context = self.get_application_context(interaction)
-        self.dispatch("application_command_run", context)
 
         try:
             await command.invoke(context)

--- a/diskord/client.py
+++ b/diskord/client.py
@@ -2457,12 +2457,12 @@ class Client:
         try:
             await command.invoke(context)
         except (ApplicationCommandError, _BaseCommandError) as error:
-            # here comes the important part, There have been many concerns about error handlers
-            # of legacy commands and application commands.
+            # here comes the important part, For those concerned about separation of error handlers
+            # of legacy commands and application commands or other stuff in general.
             # we need seperate handlers for each type, the reason behind this is purely
             # based on the fact that prefixed commands are NOT same as application commands
             # and have different implementation. there can be more complicated issues
-            # if we merge the handlers or in general, these two unlike systems so there
+            # if we merge the handlers or anything about these two unlike systems so there
             # is no possibility of them to be merged in one!
             self.dispatch("application_command_error", context, error)
         else:

--- a/diskord/enums.py
+++ b/diskord/enums.py
@@ -560,6 +560,7 @@ class InteractionType(Enum):
     ping = 1
     application_command = 2
     component = 3
+    application_command_autocomplete = 4
 
 
 class InteractionResponseType(Enum):
@@ -570,6 +571,7 @@ class InteractionResponseType(Enum):
     deferred_channel_message = 5  # (with source)
     deferred_message_update = 6  # for components
     message_update = 7  # for components
+    application_command_autocomplete_result = 8 # for application commands
 
 
 class VideoQualityMode(Enum):

--- a/diskord/interactions.py
+++ b/diskord/interactions.py
@@ -686,6 +686,41 @@ class InteractionResponse:
 
         self._responded = True
 
+    async def autocomplete(self, choices: List[OptionChoice]):
+        """|coro|
+
+        Respond to an :attr:`InteractionType.application_command_autocomplete`
+        interaction as such this method takes a list of choices that would
+        be viewed as predicted :class:`~diskord.OptionChoice`.
+
+        This function shouldn't generally be called manually, Library provides
+        a rich interface for handling autocompletions that should be used
+        instead.
+
+        Parameters
+        ----------
+        choices: List[:class:`OptionChoice`]
+            The list of choices that would be shown to user. Can be no more
+            then 25.
+        """
+        if self._responded:
+            raise InteractionResponded(self._parent)
+
+        parent = self._parent
+        payload = {'choices': [choice.to_dict() for choice in choices]}
+
+        if parent.type is InteractionType.application_command_autocomplete:
+            adapter = async_context.get()
+            await adapter.create_interaction_response(
+                parent.id,
+                parent.token,
+                session=parent._session,
+                type=InteractionResponseType.application_command_autocomplete_result.value,
+                data=payload,
+            )
+            self._responded = True
+
+
 
 class _InteractionMessageState:
     __slots__ = ("_parent", "_interaction")

--- a/diskord/types/interactions.py
+++ b/diskord/types/interactions.py
@@ -55,6 +55,8 @@ class ApplicationCommand(_ApplicationCommandOptional):
 class _ApplicationCommandOptionOptional(TypedDict, total=False):
     choices: List[ApplicationCommandOptionChoice]
     options: List[ApplicationCommandOption]
+    autocomplete: bool
+    focused: bool
 
 
 ApplicationCommandOptionType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

--- a/diskord/types/interactions.py
+++ b/diskord/types/interactions.py
@@ -56,8 +56,6 @@ class _ApplicationCommandOptionOptional(TypedDict, total=False):
     choices: List[ApplicationCommandOptionChoice]
     options: List[ApplicationCommandOption]
     autocomplete: bool
-    focused: bool
-
 
 ApplicationCommandOptionType = Literal[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
@@ -101,6 +99,8 @@ InteractionType = Literal[1, 2, 3]
 
 class _ApplicationCommandInteractionDataOption(TypedDict):
     name: str
+    focused: bool
+
 
 
 class _ApplicationCommandInteractionDataOptionSubcommand(


### PR DESCRIPTION
## Summary
This pull request implements options auto-completion for slash commands. This based on [this notion](https://devsnek.notion.site/devsnek/Application-Command-Option-Autocomplete-Interactions-dacc980320c948768cec5ae3a96a5886).

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Confirmations
<!-- Read and tick each and everyone of these, if any of these conditions do not apply, Your PR can be rejected for potential reasons. :( -->

- [x] I have checked the open PRs and no PR exists like this one.
- [x] My PR focuses on only one issue/change.
