### PR TITLE
Implement thread starter message

### DIFF
--- a/diskord/state.py
+++ b/diskord/state.py
@@ -250,7 +250,6 @@ class ConnectionState:
             cache_flags._verify_intents(intents)
 
         self.member_cache_flags: MemberCacheFlags = cache_flags
-        self.thread_cache_starter_messages = {}
         self._activity: Optional[ActivityPayload] = activity
         self._status: Optional[str] = status
         self._intents: Intents = intents

--- a/diskord/state.py
+++ b/diskord/state.py
@@ -250,6 +250,7 @@ class ConnectionState:
             cache_flags._verify_intents(intents)
 
         self.member_cache_flags: MemberCacheFlags = cache_flags
+        self.thread_cache_starter_messages = {}
         self._activity: Optional[ActivityPayload] = activity
         self._status: Optional[str] = status
         self._intents: Intents = intents

--- a/diskord/threads.py
+++ b/diskord/threads.py
@@ -132,7 +132,6 @@ class Thread(Messageable, Hashable):
         "_members",
         "owner_id",
         "parent_id",
-        "_starter_message",
         "last_message_id",
         "message_count",
         "member_count",
@@ -150,7 +149,6 @@ class Thread(Messageable, Hashable):
         self._state: ConnectionState = state
         self.guild = guild
         self._members: Dict[int, ThreadMember] = {}
-        self._starter_message = None
         self._from_data(data)
 
     async def _get_channel(self):
@@ -234,26 +232,6 @@ class Thread(Messageable, Hashable):
         needed.
         """
         return list(self._members.values())
-
-    @property
-    def starter_message(self) -> Optional[Message]:
-        """Gets the message that the thread was created from in cache.
-
-        It can be None in case the thread was not made from a message or fetch_starter_message was never called.
-
-        .. admonition:: Reliable Fetching
-            :class: helpful
-
-            For a slightly more reliable method of fetching the
-            starter message, consider using :meth:`fetch_starter_message`
-            method.
-
-        Returns
-        ---------
-        Optional[:class:`Message`]
-            The message that the thread was created from or ``None``.
-        """
-        return self._starter_message
 
     @property
     def last_message(self) -> Optional[Message]:
@@ -750,8 +728,7 @@ class Thread(Messageable, Hashable):
         :class:`Message`
             The message that the thread was created from.
         """
-        self._starter_message = await self.parent.fetch_message(self.id)
-        return self._starter_message
+        return await self.parent.fetch_message(self.id)
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.

--- a/diskord/threads.py
+++ b/diskord/threads.py
@@ -713,6 +713,23 @@ class Thread(Messageable, Hashable):
         """
         await self._state.http.delete_channel(self.id)
 
+    async def fetch_starter_message(self) -> Optional[Message]:
+        """Fetches the message that the thread was created from.
+
+        It can be None in case the thread was not made from a message.
+
+        Raises
+        -------
+        HTTPException
+            Retrieving the message failed.
+
+        Returns
+        ---------
+        Optional[:class:`Message`]
+            The message that the thread was created from or ``None`` if not found.
+        """
+        return await self.parent.fetch_message(self.id)
+
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.
 

--- a/diskord/threads.py
+++ b/diskord/threads.py
@@ -234,6 +234,26 @@ class Thread(Messageable, Hashable):
         return list(self._members.values())
 
     @property
+    def starter_message(self) -> Optional[Message]:
+        """Gets the message that the thread was created from.
+
+        It can be None in case the thread was not made from a message or fetch_starter_message was never called.
+
+        .. admonition:: Reliable Fetching
+            :class: helpful
+
+            For a slightly more reliable method of fetching the
+            starter message, consider using :meth:`fetch_starter_message`
+            method.
+
+        Returns
+        ---------
+        Optional[:class:`Message`]
+            The message that the thread was created from or ``None``.
+        """
+        return self._state.thread_cache_starter_messages.get(self.id)
+
+    @property
     def last_message(self) -> Optional[Message]:
         """Fetches the last message from this channel in cache.
 
@@ -728,7 +748,9 @@ class Thread(Messageable, Hashable):
         Optional[:class:`Message`]
             The message that the thread was created from or ``None`` if not found.
         """
-        return await self.parent.fetch_message(self.id)
+        message = await self.parent.fetch_message(self.id)
+        self._state.thread_cache_starter_messages[self.id] = message
+        return message
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.

--- a/diskord/threads.py
+++ b/diskord/threads.py
@@ -132,6 +132,7 @@ class Thread(Messageable, Hashable):
         "_members",
         "owner_id",
         "parent_id",
+        "_starter_message",
         "last_message_id",
         "message_count",
         "member_count",
@@ -149,6 +150,7 @@ class Thread(Messageable, Hashable):
         self._state: ConnectionState = state
         self.guild = guild
         self._members: Dict[int, ThreadMember] = {}
+        self._starter_message = None
         self._from_data(data)
 
     async def _get_channel(self):
@@ -251,7 +253,7 @@ class Thread(Messageable, Hashable):
         Optional[:class:`Message`]
             The message that the thread was created from or ``None``.
         """
-        return self._state.thread_cache_starter_messages.get(self.id)
+        return self._starter_message
 
     @property
     def last_message(self) -> Optional[Message]:
@@ -748,9 +750,8 @@ class Thread(Messageable, Hashable):
         :class:`Message`
             The message that the thread was created from.
         """
-        message = await self.parent.fetch_message(self.id)
-        self._state.thread_cache_starter_messages[self.id] = message
-        return message
+        self._starter_message = await self.parent.fetch_message(self.id)
+        return self._starter_message
 
     def get_partial_message(self, message_id: int, /) -> PartialMessage:
         """Creates a :class:`PartialMessage` from the message ID.

--- a/diskord/threads.py
+++ b/diskord/threads.py
@@ -736,7 +736,7 @@ class Thread(Messageable, Hashable):
     async def fetch_starter_message(self) -> Message:
         """Fetches the message that the thread was created from.
 
-        If the thread was created from a message, the Message type will be `default`, otherwise it will be `thread_starter_message`.
+        If the thread was created from a message, the message type will be `default`, otherwise it will be `thread_starter_message`.
 
         Raises
         -------

--- a/diskord/threads.py
+++ b/diskord/threads.py
@@ -235,7 +235,7 @@ class Thread(Messageable, Hashable):
 
     @property
     def starter_message(self) -> Optional[Message]:
-        """Gets the message that the thread was created from.
+        """Gets the message that the thread was created from in cache.
 
         It can be None in case the thread was not made from a message or fetch_starter_message was never called.
 
@@ -733,10 +733,10 @@ class Thread(Messageable, Hashable):
         """
         await self._state.http.delete_channel(self.id)
 
-    async def fetch_starter_message(self) -> Optional[Message]:
+    async def fetch_starter_message(self) -> Message:
         """Fetches the message that the thread was created from.
 
-        It can be None in case the thread was not made from a message.
+        If the thread was created from a message, the Message type will be `default`, otherwise it will be `thread_starter_message`.
 
         Raises
         -------
@@ -745,8 +745,8 @@ class Thread(Messageable, Hashable):
 
         Returns
         ---------
-        Optional[:class:`Message`]
-            The message that the thread was created from or ``None`` if not found.
+        :class:`Message`
+            The message that the thread was created from.
         """
         message = await self.parent.fetch_message(self.id)
         self._state.thread_cache_starter_messages[self.id] = message


### PR DESCRIPTION
## Summary
So I added a method to diskord.Thread that fetches the message that the thread was created from.
The method is called `fetch_starter_message` and it will return a diskord.Message.
If the thread was created from a message, the message type will be `default`, otherwise it will be `thread_starter_message`.
I also added a property called `starter_message` that will return the thread starter_message from the cache (can be None).
The cache is updated everytime `fetch_starter_message` is called.
This property can be useful when you don't want to make another API call after you already did.

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] This PR is **not** a code change (e.g. documentation, README, ...)
