### PR TITLE
Make application commands register on `login`

### DIFF
--- a/diskord/client.py
+++ b/diskord/client.py
@@ -558,6 +558,7 @@ class Client:
 
         data = await self.http.static_login(token.strip())
         self._connection.user = ClientUser(state=self._connection, data=data)
+        await self.register_application_commands()
 
     async def connect(self, *, reconnect: bool = True) -> None:
         """|coro|
@@ -2275,8 +2276,3 @@ class Client:
                 )
 
         return cls(self, interaction)
-
-    # Events
-
-    async def on_connect(self):
-        await self.register_application_commands()


### PR DESCRIPTION
<!-- Thanks for your contribution. It means a lot to us. Even a minor contribution makes impact. :) -->

## Summary
Make application commands register on `login` instead of `on_connect` event so you don't have to manually register the slash commands when u call a `on_connect`.
<!-- Please explain your pull request here. What does it do? Explain it in detail. -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] | Check the boxes that are relevant to your pull request -->

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

## Confirmations
<!-- Read and tick each and everyone of these, if any of these conditions do not apply, Your PR can be rejected for potential reasons. :( -->

- [x] I have checked the open PRs and no PR exists like this one.
- [x] My PR focuses on only one issue/change.
